### PR TITLE
Add explicit dependency for jackson annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${jacksonVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jacksonVersion}</version>
+      </dependency>
       <!-- END: JAX-RS support -->
       
       <dependency>


### PR DESCRIPTION
Fix the error on using ObjectMapper:
  java.lang.NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonMerge

The cause is the mismatch between the jackson versions
if there is no explicit dependency:

mvn dependency:tree
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.7:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.8.8:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.9.7:compile