### PR TITLE
Implement content-audit publisher SPI for Kafka

### DIFF
--- a/content-audit/kafka-publisher/pom.xml
+++ b/content-audit/kafka-publisher/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/propulsor)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.commonjava.propulsor.content-audit</groupId>
+    <artifactId>propulsor-content-audit</artifactId>
+    <version>1.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>propulsor-content-audit-kafka-publisher</artifactId>
+  <name>Propulsor :: Content Audit :: Kafka Publisher</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.commonjava.propulsor.content-audit</groupId>
+      <artifactId>propulsor-content-audit-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/content-audit/kafka-publisher/pom.xml
+++ b/content-audit/kafka-publisher/pom.xml
@@ -27,6 +27,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.commonjava.propulsor.config</groupId>
+      <artifactId>propulsor-configuration-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/KafkaPublisher.java
+++ b/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/KafkaPublisher.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/propulsor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.propulsor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.commonjava.propulsor.content.audit.FileEventPublisher;
+import org.commonjava.propulsor.content.audit.FileEventPublisherException;
+import org.commonjava.propulsor.content.audit.model.FileEvent;
+import org.commonjava.propulsor.content.audit.model.FileGroupingEvent;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+
+public class KafkaPublisher
+                implements FileEventPublisher
+{
+
+    private static final String PROP_PATH = "publisher.properties";
+
+    private String topic;
+
+    private Properties props;
+
+    private ResultHandler handler;
+
+    private Producer<String, String> producer;
+
+    public KafkaPublisher( String bootStrapServers, String topic, ResultHandler handler )
+    {
+        this.topic = topic;
+        this.handler = handler;
+
+        initProperties( bootStrapServers );
+
+        producer = new KafkaProducer<>( props );
+    }
+
+    private void initProperties( String bootStrapServers )
+    {
+        props = new Properties();
+
+        FileInputStream fis = null;
+        try
+        {
+            fis = new FileInputStream( new File( PROP_PATH ) );
+            props.load( fis );
+        }
+        catch ( Exception e )
+        {
+            throw new FileEventPublisherException( "Load configuration failed.", e );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( fis );
+        }
+
+        props.put( ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootStrapServers );
+    }
+
+    @Override
+    public void publishFileEvent( FileEvent fileEvent ) throws FileEventPublisherException
+    {
+        doPublish( fileEvent.getEventId().toString(), writeValueAsString( fileEvent ) );
+    }
+
+    @Override
+    public void publishFileGroupingEvent( FileGroupingEvent fileGroupingEvent ) throws FileEventPublisherException
+    {
+        doPublish( fileGroupingEvent.getEventId().toString(), writeValueAsString( fileGroupingEvent ) );
+    }
+
+    private String writeValueAsString( Object value )
+    {
+        try
+        {
+            return new ObjectMapper().writeValueAsString( value );
+        }
+        catch ( JsonProcessingException e )
+        {
+            throw new FileEventPublisherException( "Convert Object to JSON error.", e );
+        }
+    }
+
+    private void doPublish( String key, String value )
+    {
+
+        ProducerRecord rp = new ProducerRecord<String, String>( topic, key, value );
+        producer.send( rp, new KafkaPublisherCallback( key, value, handler ) );
+
+    }
+
+    public void close()
+    {
+        producer.close();
+    }
+
+}

--- a/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/KafkaPublisherCallback.java
+++ b/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/KafkaPublisherCallback.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/propulsor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.propulsor;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaPublisherCallback implements Callback
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private String key;
+
+    private String value;
+
+    private ResultHandler handler;
+
+    public KafkaPublisherCallback( String key, String value, ResultHandler handler )
+    {
+        this.key = key;
+        this.value = value;
+        this.handler = handler;
+    }
+
+    @Override
+    public void onCompletion( RecordMetadata recordMetadata, Exception e )
+    {
+        if ( handler != null )
+        {
+            handler.handle( key, value, e );
+        }
+        else
+        {
+            logger.warn( "There is no default handler setting." );
+        }
+    }
+}

--- a/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/ResultHandler.java
+++ b/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/ResultHandler.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/propulsor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.propulsor;
+
+/**
+ * This interface provides methods to handle the result from kafka publisher
+ */
+public interface ResultHandler
+{
+
+    void handle( String key, String value, Exception e );
+
+}

--- a/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/conf/KafkaPublisherConfig.java
+++ b/content-audit/kafka-publisher/src/main/java/org/commonjava/propulsor/conf/KafkaPublisherConfig.java
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 
-package org.commonjava.propulsor;
+package org.commonjava.propulsor.conf;
 
-/**
- * This interface provides methods to handle the result from kafka publisher
- */
-@FunctionalInterface
-public interface ResultHandler
+import org.commonjava.propulsor.config.annotation.SectionName;
+import org.commonjava.propulsor.config.section.PropertiesSectionListener;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@SectionName("publisher.kafka")
+public class KafkaPublisherConfig extends PropertiesSectionListener
 {
 
-    void handle( String key, String value, Exception e );
+    private String topic;
+
+    public String getTopic() { return topic; }
+
+    public void setTopic( String topic ) { this.topic = topic; }
 
 }

--- a/content-audit/kafka-publisher/src/main/resources/publisher.properties
+++ b/content-audit/kafka-publisher/src/main/resources/publisher.properties
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/propulsor)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client
+# will make use of all servers irrespective of which servers are specified here for bootstrapping—this list
+# only impacts the initial hosts used to discover the full set of servers. This list should be in the form
+#
+# host1:port1,host2:port2,....
+#
+# Since these servers are just used for the initial connection to discover the full cluster membership
+# (which may change dynamically), this list need not contain the full set of servers (you may want more
+# than one, though, in case a server is down).
+bootstrap.servers=localhost:9092
+
+# Serializer class for key that implements the org.apache.kafka.common.serialization.Serializer interface.
+key.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Serializer class for value that implements the org.apache.kafka.common.serialization.Serializer interface.
+value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# The number of acknowledgments the producer requires the leader to have received before considering a
+# request complete. This controls the durability of records that are sent.
+acks=all
+
+#buffer.memory
+
+retries=3
+
+linger.ms=1
+
+# The configuration controls how long KafkaProducer.send() and KafkaProducer.partitionsFor() will block.
+# These methods can be blocked either because the buffer is full or metadata unavailable.Blocking in the
+# user-supplied serializers or partitioner will not be counted against this timeout.
+max.block.ms=5000

--- a/content-audit/pom.xml
+++ b/content-audit/pom.xml
@@ -31,5 +31,6 @@
 
     <modules>
         <module>api</module>
+        <module>kafka-publisher</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,17 @@
       </dependency>
 
       <dependency>
+        <groupId>org.commonjava.propulsor.content-audit</groupId>
+        <artifactId>propulsor-content-audit-api</artifactId>
+        <version>1.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.propulsor.content-audit</groupId>
+        <artifactId>propulsor-content-audit-kafka-publisher</artifactId>
+        <version>1.3-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>
@@ -329,6 +340,12 @@
         <scope>test</scope>
       </dependency>
 
+      <!-- Kafka -->
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>2.0.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   


### PR DESCRIPTION
The kafka producer client itself ( not broker ) needs some [configuration](https://kafka.apache.org/documentation/#producerconfigs) except the server host/port, i put it under src/main/resources with some basic ones and default values. 

