### PR TITLE
Fixing NPEs, sanitizing interpolation, fixing coercion

### DIFF
--- a/configuration/core/src/main/java/org/commonjava/propulsor/config/ConfigUtils.java
+++ b/configuration/core/src/main/java/org/commonjava/propulsor/config/ConfigUtils.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 John Casey (jdcasey@commonjava.org)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,11 +20,25 @@ import org.commonjava.propulsor.config.section.ConfigurationSectionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Properties;
+
 public final class ConfigUtils
 {
 
     private ConfigUtils()
     {
+    }
+
+    public static Properties loadStandardConfigProperties()
+    {
+        Properties props = new Properties();
+
+        Properties sysprops = System.getProperties();
+        sysprops.stringPropertyNames().forEach( ( name ) -> props.setProperty( name, sysprops.getProperty( name ) ) );
+
+        System.getenv().forEach( ( k, v ) -> props.setProperty( "env." + k, v ) );
+
+        return props;
     }
 
     public static String getSectionName( Class<?> cls )

--- a/configuration/core/src/main/java/org/commonjava/propulsor/config/io/ConfigFileUtils.java
+++ b/configuration/core/src/main/java/org/commonjava/propulsor/config/io/ConfigFileUtils.java
@@ -55,25 +55,13 @@ public final class ConfigFileUtils
     public static InputStream readFileWithIncludes( final String path )
             throws IOException, ConfigurationException
     {
-        return readFileWithIncludes( new File( path ), null );
-    }
-
-    public static InputStream readFileWithIncludes( final String path, Properties props )
-            throws IOException, ConfigurationException
-    {
-        return readFileWithIncludes( new File( path ), props );
+        return readFileWithIncludes( new File( path ) );
     }
 
     public static InputStream readFileWithIncludes( final File f )
             throws IOException, ConfigurationException
     {
-        return readFileWithIncludes( f, null );
-    }
-
-    public static InputStream readFileWithIncludes( final File f, Properties props )
-            throws IOException, ConfigurationException
-    {
-        final List<String> lines = readLinesWithIncludes( f, props, false );
+        final List<String> lines = readLinesWithIncludes( f, false );
 
         return new ByteArrayInputStream( join( lines, LS ).getBytes() );
     }
@@ -95,16 +83,10 @@ public final class ConfigFileUtils
     public static List<String> readLinesWithIncludes( final File f )
             throws IOException, ConfigurationException
     {
-        return readLinesWithIncludes( f, null, false );
+        return readLinesWithIncludes( f, false );
     }
 
-    public static List<String> readLinesWithIncludes( final File f, Properties props )
-            throws IOException, ConfigurationException
-    {
-        return readLinesWithIncludes( f, props, false );
-    }
-
-    public static List<String> readLinesWithIncludes( final File f, Properties props, boolean ignoreVariables )
+    public static List<String> readLinesWithIncludes( final File f, boolean ignoreVariables )
             throws IOException, ConfigurationException
     {
         Properties vars = new Properties();
@@ -118,7 +100,7 @@ public final class ConfigFileUtils
                 final String glob = line.substring( INCLUDE_COMMAND.length() );
                 for ( final File file : findMatching( dir, glob ) )
                 {
-                    lines.addAll( readLinesWithIncludes( file, null, true ) );
+                    lines.addAll( readLinesWithIncludes( file, true ) );
                 }
             }
             else if ( !ignoreVariables && line.startsWith( VARIABLES_COMMAND ) )
@@ -145,26 +127,7 @@ public final class ConfigFileUtils
             }
         }
 
-        StringSearchInterpolator ssi = new StringSearchInterpolator();
-        ssi.addValueSource( new PropertiesBasedValueSource( props ) );
-        ssi.addValueSource( new PropertiesBasedValueSource( vars ) );
-        ssi.addValueSource( new PropertiesBasedValueSource( System.getProperties() ) );
-
-        List<String> result = new ArrayList<String>();
-        for ( String line : lines )
-        {
-            try
-            {
-                result.add( ssi.interpolate( line ) );
-            }
-            catch ( InterpolationException e )
-            {
-                throw new ConfigurationException( "Failed to resolve expressions in '%s'. Reason: %s", e, line,
-                                                  e.getMessage() );
-            }
-        }
-
-        return result;
+        return lines;
     }
 
     public static File[] findMatching( final File dir, String glob )

--- a/configuration/core/src/main/java/org/commonjava/propulsor/config/section/BeanSectionListener.java
+++ b/configuration/core/src/main/java/org/commonjava/propulsor/config/section/BeanSectionListener.java
@@ -259,7 +259,7 @@ public class BeanSectionListener<T>
 
         for ( Map.Entry<String, MethodInvoker> entry : methodMap.entrySet() )
         {
-            logger.debug( "Invoking: {}", entry.getValue().method );
+            logger.debug( "Invoking: {} on instance: {}", entry.getValue().method, instance );
 
             try
             {
@@ -278,7 +278,7 @@ public class BeanSectionListener<T>
 
         if ( unsetPropertiesMethod != null && !unmatched.isEmpty() )
         {
-            logger.debug( "Invoking unset-properties method: {}", unsetPropertiesMethod );
+            logger.debug( "Invoking unset-properties method: {} on instance: {}", unsetPropertiesMethod, instance );
 
             try
             {
@@ -333,7 +333,16 @@ public class BeanSectionListener<T>
 
         void invoke( Object instance ) throws InvocationTargetException, IllegalAccessException
         {
-            method.invoke( instance, param );
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            if ( param == null )
+            {
+                logger.debug( "NOT INV method: {} on: {}. Parameter is null!", method, instance );
+            }
+            else
+            {
+                logger.debug( "INV method: {} on: {} with param: {}", method, instance, param );
+                method.invoke( instance, param );
+            }
         }
     }
 
@@ -356,6 +365,8 @@ public class BeanSectionListener<T>
 
         T invoke() throws IllegalAccessException, InvocationTargetException, InstantiationException
         {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.debug( "INV ctor: {} with args: {}", ctor, args );
             return ctor.newInstance( args );
         }
     }

--- a/configuration/core/src/main/java/org/commonjava/propulsor/config/section/Coercions.java
+++ b/configuration/core/src/main/java/org/commonjava/propulsor/config/section/Coercions.java
@@ -16,9 +16,12 @@
 package org.commonjava.propulsor.config.section;
 
 import org.commonjava.propulsor.config.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,12 +33,25 @@ public final class Coercions
     static
     {
         typeCoercions.put( String.class, s -> s );
+
+        typeCoercions.put( Integer.TYPE, s-> Integer.valueOf( s ) );
         typeCoercions.put( Integer.class, s -> Integer.valueOf( s ) );
+
+        typeCoercions.put( Long.TYPE, s -> Long.valueOf( s ) );
         typeCoercions.put( Long.class, s -> Long.valueOf( s ) );
+
+        typeCoercions.put( Short.TYPE, s -> Short.valueOf( s ) );
         typeCoercions.put( Short.class, s -> Short.valueOf( s ) );
+
+        typeCoercions.put( Float.TYPE, s -> Float.valueOf( s ) );
         typeCoercions.put( Float.class, s -> Float.valueOf( s ) );
+
+        typeCoercions.put( Double.TYPE, s -> Double.valueOf( s ) );
         typeCoercions.put( Double.class, s -> Double.valueOf( s ) );
+
         typeCoercions.put( File.class, s -> new File( s ) );
+
+        typeCoercions.put( Boolean.TYPE, s -> Boolean.valueOf( s ) );
         typeCoercions.put( Boolean.class, s -> Boolean.valueOf( s ) );
     }
 
@@ -45,6 +61,9 @@ public final class Coercions
 
     public static Object coerce( String param, Class<?> ptype, Object source ) throws ConfigurationException
     {
+        Logger logger = LoggerFactory.getLogger( Coercions.class );
+        logger.debug( "Retrieving coercion for: {}", ptype );
+
         Function<String, Object> func = typeCoercions.get( ptype );
         if ( func != null )
         {

--- a/configuration/core/src/test/java/org/commonjava/propulsor/config/io/ConfigFileUtilsTest.java
+++ b/configuration/core/src/test/java/org/commonjava/propulsor/config/io/ConfigFileUtilsTest.java
@@ -34,17 +34,6 @@ public class ConfigFileUtilsTest
 {
 
     @Test
-    public void variablesResolvedFromVarsDGlobVariables()
-            throws IOException, ConfigurationException
-    {
-        final File dir = getResourcesDir();
-        final InputStream stream = ConfigFileUtils.readFileWithIncludes( new File( dir, "main.conf" ) );
-        final String config = IOUtils.toString( stream );
-
-        assertThat( config.contains( "some.other.config = blat" ), equalTo( true ) );
-    }
-
-    @Test
     public void readConfigFileWithConfDGlobIncludes()
             throws IOException, ConfigurationException
     {

--- a/configuration/dotconf/src/main/java/org/commonjava/propulsor/config/dotconf/DotConfConfigurationReader.java
+++ b/configuration/dotconf/src/main/java/org/commonjava/propulsor/config/dotconf/DotConfConfigurationReader.java
@@ -16,6 +16,7 @@
 package org.commonjava.propulsor.config.dotconf;
 
 import static org.apache.commons.io.IOUtils.readLines;
+import static org.commonjava.propulsor.config.ConfigUtils.loadStandardConfigProperties;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,7 +86,7 @@ public class DotConfConfigurationReader
     public void loadConfiguration( final InputStream stream )
         throws ConfigurationException
     {
-        loadConfiguration( stream, System.getProperties() );
+        loadConfiguration( stream, loadStandardConfigProperties() );
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,6 @@
         <artifactId>propulsor-configuration-dotconf</artifactId>
         <version>1.4-SNAPSHOT</version>
       </dependency>
-      <dependency>
-        <groupId>org.commonjava.propulsor.config</groupId>
-        <artifactId>propulsor-configuration-yaml</artifactId>
-        <version>1.3-SNAPSHOT</version>
-      </dependency>
 
       <dependency>
         <groupId>org.commonjava.propulsor.content-audit</groupId>


### PR DESCRIPTION
We had a reference to the YAML config format, which I haven't finished, so I took it out.

There were a couple of NPE places after I replaced the old xbeans-reflect code, so I fixed those.

Interpolation was happening BOTH when we read the config file with its logic to inline
included files AND in the main configuration process. I removed the interpolation in the
config-file inlining process to reduce opportunity for nasty surprises.

I added a method in ConfigUtils called loadStandardConfigProperties() which loads
System.getProperties and then overlays System.getenv(), with all envar keys prefixed
by 'env.'.

Finally, we had some problems where setters accepted primitive types, and coercion was failing.
I fixed using Integer.TYPE and so on.