### PR TITLE
Enable Undertow on HTTP/2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,8 @@
     <httpTestserverVersion>1.3</httpTestserverVersion>
 
     <resteasyVersion>3.1.4.Final</resteasyVersion>
-    <undertowVersion>2.0.27.Final</undertowVersion>
+    <undertowVersion>2.2.2.Final</undertowVersion>
+    <xnioApiVersion>3.8.0.Final</xnioApiVersion>
     <jacksonVersion>2.10.1</jacksonVersion>
     <weldVersion>2.4.6.Final</weldVersion>
     <swaggerVersion>1.5.16</swaggerVersion>
@@ -198,6 +199,12 @@
         <groupId>org.jboss.spec.javax.servlet</groupId>
         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
         <version>1.0.2.Final</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-api</artifactId>
+        <version>${xnioApiVersion}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <httpTestserverVersion>1.3</httpTestserverVersion>
 
     <resteasyVersion>3.1.4.Final</resteasyVersion>
-    <undertowVersion>2.2.2.Final</undertowVersion>
+    <undertowVersion>2.0.27.Final</undertowVersion>
     <xnioApiVersion>3.8.0.Final</xnioApiVersion>
     <jacksonVersion>2.10.1</jacksonVersion>
     <weldVersion>2.4.6.Final</weldVersion>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -72,7 +72,11 @@
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>

--- a/undertow/src/main/java/org/commonjava/propulsor/deploy/undertow/UndertowDeployer.java
+++ b/undertow/src/main/java/org/commonjava/propulsor/deploy/undertow/UndertowDeployer.java
@@ -16,6 +16,7 @@
 package org.commonjava.propulsor.deploy.undertow;
 
 import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
 import io.undertow.predicate.Predicate;
 import io.undertow.predicate.Predicates;
 import io.undertow.server.HttpHandler;
@@ -136,6 +137,7 @@ public class UndertowDeployer
                     {
                         usingPort.set( foundPort );
                         undertow = Undertow.builder()
+                                           .setServerOption( UndertowOptions.ENABLE_HTTP2, true )
                                            .setHandler( getHandler( dm ) )
                                            .addHttpListener( foundPort, bootOptions.getBind() )
                                            .build();


### PR DESCRIPTION
As subject.
To me, this seems the only thing we need to enable HTTP/2 on Undertow. 